### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pyrogram
+tgcrypto
+python-dotenv


### PR DESCRIPTION
Memudahkan pengguna untuk menginstall library yang wajib diinstall
hanya dengan menggunakan perintah `python -m pip install requirements.txt`

Signed-off-by: Muhammad Rizki <riskimuhammmad1@gmail.com>